### PR TITLE
Adds upcoming talk by Catalin

### DIFF
--- a/_posts/2019-12-05-css-talk27.md
+++ b/_posts/2019-12-05-css-talk27.md
@@ -18,7 +18,7 @@ image:
 ---
 **Who:** Catalin Hritcu from Inria Paris, France \\
 **When:**  14:00 - 15:00 Thursday {{ page.date | date_to_long_string }}\\
-**Where:**  Room ES52, EDIT building.\\
+**Where:**  Room ES52, Linsen (Maskingränd 2).\\
 **Title: {{ page.title }}**
 
 **Abstract:**\\

--- a/_posts/2019-12-05-css-talk27.md
+++ b/_posts/2019-12-05-css-talk27.md
@@ -1,0 +1,69 @@
+---
+layout: page
+header:
+   image_fullwidth: title.jpg
+sidebar: left
+subheadline: "Chalmers Security Seminar"
+title: "When Good Components Go Bad: Formally Secure Compilation Despite Dynamic Compromise"
+teaser: "We propose a new formal criterion for evaluating secure
+  compartmentalization schemes for unsafe languages like C and C++,
+  expressing end-to-end security guarantees for software components that
+  may become compromised after encountering undefined behavior---for
+  example, by accessing an array out of bounds."
+tags: #tags are like keywords
+    - csstalk
+categories: talk
+image:
+
+---
+**Who:** Catalin Hritcu from Inria Paris, France \\
+**When:**  14:00 - 15:00 Thursday {{ page.date | date_to_long_string }}\\
+**Where:**  Room ES52, EDIT building.\\
+**Title: {{ page.title }}**
+
+**Abstract:**\\
+
+We propose a new formal criterion for evaluating secure
+compartmentalization schemes for unsafe languages like C and C++,
+expressing end-to-end security guarantees for software components that
+may become compromised after encountering undefined behavior---for
+example, by accessing an array out of bounds. Our criterion is the
+first to model dynamic compromise in a system of mutually distrustful
+components with clearly specified privileges. It articulates how each
+component should be protected from all the others---in particular,
+from components that have encountered undefined behavior and become
+compromised.
+To illustrate the model, we construct a secure compilation chain for a
+small unsafe language with buffers, procedures, and components,
+targeting a simple abstract machine with built-in
+compartmentalization. We propose a novel proof technique and give a
+machine-checked proof in Coq that this compiler satisfies our secure
+compilation criterion. Finally, we show that the protection guarantees
+offered by the compartmentalized abstract machine can be achieved at
+the machine-code level using either software fault isolation or a
+tag-based reference monitor.
+
+**Speaker Bio:**\\
+
+Catalin Hritcu (https://prosecco.gforge.inria.fr/personal/hritcu) is a
+researcher at Inria Paris where he works on security foundations. He
+is particularly interested in formal methods for security (secure
+compilation, compartmentalization, memory safety, security protocols,
+integrity, information flow), programming languages (program
+verification, proof assistants, type systems, semantics, formal
+metatheory, certified tools, property-based testing), and the design
+and verification of security-critical systems (reference monitors,
+secure compilation chains, secure hardware). He was awarded an ERC
+Starting Grant on formally secure compilation
+(https://secure-compilation.github.io), and is also actively involved
+in the design of the F* verification system
+(https://www.fstar-lang.org/), which is used for building a formally
+verified HTTPS stack (https://project-everest.github.io). Catalin
+received a PhD from Saarland University in Saarbrücken, a Habilitation
+from ENS Paris, and was previously also a Research Associate at
+University of Pennsylvania and a Visiting Researcher at Microsoft
+Research Redmond.
+
+## Previous Talks
+{: .t60 }
+{% include list-posts tag='csstalk'%}


### PR DESCRIPTION
I noticed that the links are being rendered as plain text. Would demarcating them as markdown or HTML links work?